### PR TITLE
Add common group shortcuts support

### DIFF
--- a/Src/Fare.IntegrationTests/XegerTests.cs
+++ b/Src/Fare.IntegrationTests/XegerTests.cs
@@ -1,20 +1,43 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
-using System.Text;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Fare.IntegrationTests
 {
     public sealed class XegerTests
     {
+        private readonly ITestOutputHelper _testOutput;
+
+        public XegerTests(ITestOutputHelper testOutput)
+        {
+            this._testOutput = testOutput;
+        }
+        
         [Theory, MemberData(nameof(RegexPatternTestCases))]
         public void GeneratedTextIsCorrect(string pattern)
         {
+            // Arrange
             const int repeatCount = 3;
-            var sut = new Fare.Xeger(pattern);
+            
+            var randomSeed = Environment.TickCount;
+            this._testOutput.WriteLine($"Random seed: {randomSeed}");
+            
+            var random = new Random(randomSeed);
+            
+            var sut = new Fare.Xeger(pattern, random);
 
-            var result = Enumerable.Repeat(0, repeatCount).Select(_ => sut.Generate()).ToArray();
+            // Act
+            var result = Enumerable.Repeat(0, repeatCount)
+                .Select(_ =>
+                {
+                    var generatedValue = sut.Generate();
+                    this._testOutput.WriteLine($"Generated value: {generatedValue}");
+                    return generatedValue;
+                })
+                .ToArray();
 
+            // Assert
             Assert.All(result, regex => Assert.Matches(pattern, regex));
         }
 
@@ -24,9 +47,17 @@ namespace Fare.IntegrationTests
         {
             const int repeatCount = 3;
             var settings = new Rex.RexSettings(pattern) { k = 1 };
-            settings.seed = 102;
+            // Fix generated value doesn't always meet the pattern
+            settings.encoding = Rex.CharacterEncoding.ASCII;
 
-            var result = Enumerable.Repeat(0, repeatCount).Select(_ => Rex.RexEngine.GenerateMembers(settings).Single()).ToArray();
+            var result = Enumerable.Repeat(0, repeatCount)
+                .Select(_ =>
+                {
+                    var generatedValue  = Rex.RexEngine.GenerateMembers(settings).Single();
+                    this._testOutput.WriteLine($"Generated value: {generatedValue}");
+                    return generatedValue;
+                })
+                .ToArray();
 
             Assert.All(result, regex => Assert.Matches(pattern, regex));
         }
@@ -74,13 +105,24 @@ namespace Fare.IntegrationTests
             @"\d{8}",
             @"\d{5}(-\d{4})?",
             @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
+            @"\D{8}",
+            @"\D{5}(-\D{4})?",
+            @"\D{1,3}\.\D{1,3}\.\D{1,3}\.\D{1,3}",
             @"^(?:[a-z0-9])+$",
             @"^(?i:[a-z0-9])+$",
             @"^(?s:[a-z0-9])+$",
             @"^(?m:[a-z0-9])+$",
             @"^(?n:[a-z0-9])+$",
             @"^(?x:[a-z0-9])+$",
-            "\\S+.*"
+            "\\S+.*",
+            @"^(?:(?:\+?1\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?$",
+            @"^\s1\s+2\s3\s?4\s*$",
+            @"(\s123)+",
+            @"\Sabc\S{3}111",
+            @"^\S\S  (\S$",
+            @"\\abc\\d",
+            @"\w+1\w{4}",
+            @"\W+1\w?2\W{4}"
         };
     }
 }


### PR DESCRIPTION
Closes #20 

Add support for the following group shortcuts:
- \s
- \S
- \w
- \W

Also improved the '\\\\', '\d' and '\D' support, so group is not matched when backslash is escaped.

In this PR I tried to partially cover the #13 and generate printable ASCII symbols only. Otherwise, if we allow to generate any Unicode chars, very often the result doesn't match the expected regular expression.