### PR TITLE
Generate ASCII symbol for any_char placeholder

### DIFF
--- a/Src/Fare/RegExp.cs
+++ b/Src/Fare/RegExp.cs
@@ -816,7 +816,7 @@ namespace Fare
                 RegExp e = this.ParseCharClasses();
                 if (negate)
                 {
-                    e = ExcludeChars(e, MakeAnyChar());
+                    e = ExcludeChars(e, MakeAnyPrintableASCIIChar());
                 }
 
                 if (!this.Match(']'))
@@ -834,7 +834,7 @@ namespace Fare
         {
             if (this.Match('.'))
             {
-                return RegExp.MakeAnyChar();
+                return MakeAnyPrintableASCIIChar();
             }
 
             if (this.Check(RegExpSyntaxOptions.Empty) && this.Match('#'))


### PR DESCRIPTION
Closes #13 

Some of the tests are still flucky due to unicode characters used for the `.` placeholder. In this PR I switch lib to use ASCII chars only for the `.` placeholder - tests are completely stable now.

Same for the groups: `[~123]` will also use only ASCII symbols (except `123`).