### PR TITLE
Fix a typo in pack in package license URL

### DIFF
--- a/Src/Fare/Fare.csproj
+++ b/Src/Fare/Fare.csproj
@@ -20,7 +20,7 @@
 
     <Authors>Nikos Baxevanis</Authors>
     <PackageProjectUrl>https://github.com/moodmosaic/Fare</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/moodmosaic/Fare/blob/master/LICENCE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://github.com/moodmosaic/Fare/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>Regex Test NFA DFA Automaton</PackageTags>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This resolves https://github.com/moodmosaic/Fare/issues/40

---

Thank you @lerppana for reporting this, and @zvirja for quickly pointing out where the package license URL is specified. 