### PR TITLE
Remove Empty option handling to fix issue 32

### DIFF
--- a/Src/Fare.IntegrationTests/Fare.IntegrationTests.csproj
+++ b/Src/Fare.IntegrationTests/Fare.IntegrationTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyTitle>Fare.IntegrationTests</AssemblyTitle>
     <AssemblyName>Fare.IntegrationTests</AssemblyName>
 

--- a/Src/Fare.IntegrationTests/XegerTests.cs
+++ b/Src/Fare.IntegrationTests/XegerTests.cs
@@ -65,6 +65,8 @@ namespace Fare.IntegrationTests
 
         public static TheoryData<string> RegexPatternTestCases => new TheoryData<string>
         {
+            @"\d{8}(#)\d{3}",   // pattern reported for issue 32
+            
             "[ab]{4,6}",
             "[ab]{4,6}c",
             "(a|b)*ab",

--- a/Src/Fare/Fare.csproj
+++ b/Src/Fare/Fare.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyTitle>Fare</AssemblyTitle>
     <AssemblyName>Fare</AssemblyName>
     <Copyright>Copyright © Nikos Baxevanis 2016</Copyright>

--- a/Src/Fare/RegExp.cs
+++ b/Src/Fare/RegExp.cs
@@ -837,10 +837,16 @@ namespace Fare
                 return MakeAnyPrintableASCIIChar();
             }
 
-            if (this.Check(RegExpSyntaxOptions.Empty) && this.Match('#'))
-            {
-                return RegExp.MakeEmpty();
-            }
+            /* Issue 32, https://github.com/moodmosaic/Fare/issues/32
+            *   The intent of the original code is a little unclear.  The comment for the Empty value in the 
+            *   enum is 'Enables empty language.'  Using '#' as token seems non-standard, and caused
+            *   unhandled exception in some cases.  The best option at this point is to remove handling of the
+            *   Empty option until a proper implementation is proposed.
+             */
+            // if (this.Check(RegExpSyntaxOptions.Empty) && this.Match('#'))
+            // {
+            //     return RegExp.MakeEmpty();
+            // }
 
             if (this.Check(RegExpSyntaxOptions.Anystring) && this.Match('@'))
             {


### PR DESCRIPTION
The change in RegExp.cs fixes issue 32 by ignoring RegExpOptions.Empty during parsing.  Added repo case to XegerTests.cs.
I included the changes target framework I used on MacOS, but you can skip them & test w/.NET Fx and older netcore.