### PR TITLE
Support netstandard2.1 cause security vulnerability

### DIFF
--- a/Src/Fare/Fare.csproj
+++ b/Src/Fare/Fare.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net35;netstandard1.1;netstandard2.1</TargetFrameworks>
     <AssemblyTitle>Fare</AssemblyTitle>
     <AssemblyName>Fare</AssemblyName>
     <Copyright>Copyright © Nikos Baxevanis 2016</Copyright>


### PR DESCRIPTION
As .netstandard1.1 has an issue in the System.Net.Http DoS known, I add support to netstandard2.1 where it was resovled.

Daniel.