### PR TITLE
Lower netstandard2.1 target to netstandard2.0

### DIFF
--- a/Src/Fare/Fare.csproj
+++ b/Src/Fare/Fare.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard1.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net35;netstandard1.1;netstandard2.0</TargetFrameworks>
     <AssemblyTitle>Fare</AssemblyTitle>
     <AssemblyName>Fare</AssemblyName>
     <Copyright>Copyright © Nikos Baxevanis 2016</Copyright>


### PR DESCRIPTION
The netstandard2.1 target was in #59 added to resolve dependency analyzers
warning against vulnerable versions of [`System.Net.Http`](https://github.com/advisories/GHSA-7jgj-8wvc-jh57) and
[`System.Text.RegularExpressions`](https://github.com/advisories/GHSA-cmhx-cq75-c4mj). 
The warnings can also be fixed by only adding a netstandard2.0 target which has a broader reach.