### PR TITLE
Remove net35 workaround

### DIFF
--- a/Src/Common.props
+++ b/Src/Common.props
@@ -6,10 +6,6 @@
 
     <Features>IOperation</Features>
     <Configurations>Debug;Release;Verify</Configurations>
-
-    <!-- A workaround for the issue .NET Core cannot build project if it contains .NET 3.5 target.
-         See more detail here: https://github.com/Microsoft/msbuild/issues/1333 -->
-    <FrameworkPathOverride Condition=" '$(TargetFramework)'=='net35' ">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
The issue it was supposed to fix seems to be resolved. 

Now, this line blocks building anywhere except Windows.